### PR TITLE
Added an option to add language prefix to the invalidation path

### DIFF
--- a/src/models/Settings.php
+++ b/src/models/Settings.php
@@ -60,7 +60,12 @@ class Settings extends Model
     /**
      * @var string CloudFront Distribution Prefix
      */
-    public $cfSuffix = '';
+    public $cfSuffix = '';    
+    
+    /**
+     * @var bool Enable language prefixing
+     */
+    public $prefixLanguage = false;
 
     // Public Methods
     // =========================================================================

--- a/src/templates/settings.twig
+++ b/src/templates/settings.twig
@@ -75,3 +75,12 @@
     value: settings.cfSuffix,
     errors: settings.getErrors('cfSuffix')
 }) }}
+
+{{ forms.lightswitchField({
+    label: "Prefix invalidation path with entry language"|t('aws-s3'),
+    instructions: "For multisite projects, enable this to prefix the Cloudfront invalidation path with the Entry language code on save (e.g. /en or /fr) "|t('aws-s3'),
+    id: 'prefixLanguage',
+    name: 'prefixLanguage',
+    on: settings.prefixLanguage,
+    errors: settings.getErrors('prefixLanguage')
+}) }}


### PR DESCRIPTION
Our team is developing a multilingual, multi-site Craft project using this plugin. Each subsite shares the same hostname, necessitating a language prefix in the URL path to differentiate languages.

Currently, we support French and English with site URLs structured as:
- 🇫🇷 FR: `https://website.com/fr`
- 🇺🇸 EN (default): `https://website.com/en` or `https://website.com/`

Due to this configuration, the invalidation path generated for an Entry was incorrect, as it lacked the language segment,

For example, updating an "About" page would incorrectly generate  `/a-propos` for French instead of `/fr/a-propos`.

### Changes

To resolve this issue, we forked the plugin to introduce an option for prefixing entry paths with the entry's site language. This ensures correct invalidation paths in localized setups.

We added a `prefixLanguage` setting to enable/disable this feature (`false` by default to avoid breaking changes).

![Screenshot](https://github.com/kayqq/craft-cloudfront-purge/assets/17227551/4d82a266-4cc6-476e-a3ef-a91078918b91)

With the `prefixLanguage` setting enabled, the entry's language is extracted from `$entry->site->language` and prefixed to the path as `$path = '/' . $this->_cfPrefix() . $languagePrefix . ltrim($uri, '/') . $this->_cfSuffix();`

Additionally, when saving an entry on the primary site, we include the unprefixed path in the invalidation request, as unprefixed paths are valid for the default language.

### Result

When saving a page in the default language (english in this example), it properly invalidate both paths (prefixed and not prefixed)

<img width="934" alt="Capture d’écran, le 2024-04-16 à 21 48 16" src="https://github.com/kayqq/craft-cloudfront-purge/assets/17227551/1ea021bf-f459-43a7-b341-de3d9d3df9a5">

For other languages, only the prefixed path is included : 

<img width="895" alt="Capture d’écran, le 2024-04-16 à 21 48 27" src="https://github.com/kayqq/craft-cloudfront-purge/assets/17227551/936532e3-0748-4b2a-9208-1fa2d4393e05">

When the `prefixLanguage` setting is disabled, the plugin functions as before, preserving the current behavior without any changes.